### PR TITLE
Fix issues with overlay and refactor

### DIFF
--- a/1024_cols.patch
+++ b/1024_cols.patch
@@ -5,7 +5,7 @@
  extern long int ftell();
  
 -char version[] = "xxd V1.10 27oct98 by Juergen Weigert";
-+char version[] = "xxd V1.10 13Jun23 by Juergen Weigert";
++char version[] = "xxd V1.10 25july23 by Juergen Weigert";
  #ifdef WIN32
  char osver[] = " (Win32)";
  #else

--- a/384_cols.patch
+++ b/384_cols.patch
@@ -5,7 +5,7 @@
  extern long int ftell();
  
 -char version[] = "xxd V1.10 27oct98 by Juergen Weigert";
-+char version[] = "xxd V1.10 13jun23 by Juergen Weigert";
++char version[] = "xxd V1.10 25july23 by Juergen Weigert";
  #ifdef WIN32
  char osver[] = " (Win32)";
  #else

--- a/512_cols.patch
+++ b/512_cols.patch
@@ -5,7 +5,7 @@
  extern long int ftell();
  
 -char version[] = "xxd V1.10 27oct98 by Juergen Weigert";
-+char version[] = "xxd V1.10 13jun23 by Juergen Weigert";
++char version[] = "xxd V1.10 25july23 by Juergen Weigert";
  #ifdef WIN32
  char osver[] = " (Win32)";
  #else

--- a/768_cols.patch
+++ b/768_cols.patch
@@ -5,7 +5,7 @@
  extern long int ftell();
  
 -char version[] = "xxd V1.10 27oct98 by Juergen Weigert";
-+char version[] = "xxd V1.10 13Jun23 by Juergen Weigert";
++char version[] = "xxd V1.10 25july23 by Juergen Weigert";
  #ifdef WIN32
  char osver[] = " (Win32)";
  #else

--- a/README.md
+++ b/README.md
@@ -29,18 +29,14 @@ Based on [https://grail.eecs.csuohio.edu/~somos/xxd.c](https://grail.eecs.csuohi
         pkgs = import nixpkgs {
           inherit system;
           overlays = [
-            xxd.overlay
+            xxd.overlays.default
           ];
         };
-      in rec
+      in
       {
-        packages = {
-          xxd = pkgs.xxd {};
-        };
-
         devShells.default = pkgs.mkShell {
           packages = [
-            packages.xxd
+            pkgs.xxd
           ];
         };
       }

--- a/default.nix
+++ b/default.nix
@@ -2,38 +2,36 @@
   pkgs,
   system,
   stdenv,
-  ...
-}: {
-  pname ? "xxd",
-  patch ? "cols_1024",
+  colWidth ? "cols_1024",
 }: let
-  version = "13jun03";
-  patches = {
+  version = "25july23";
+  patchFiles = {
     cols_1024 = ./1024_cols.patch;
     cols_768 = ./768_cols.patch;
     cols_512 = ./512_cols.patch;
     cols_384 = ./384_cols.patch;
   };
 in
-stdenv.mkDerivation {
-  pname = pname;
-  version = version;
+  stdenv.mkDerivation {
+    pname = "xxd";
+    inherit version;
 
-  nativeBuildInputs = [pkgs.pkg-config];
+    nativeBuildInputs = [pkgs.pkg-config];
 
-  makeFlags = ["DESTDIR=${placeholder "out"}"];
-  targetSharePath = "${placeholder "out"}/share";
+    makeFlags = ["DESTDIR=${placeholder "out"}"];
+    targetSharePath = "${placeholder "out"}/share";
 
-  src = ./.;
-  patches = [
-    patches.${patch}
-  ];
+    src = ./.;
 
-  preInstall = ''
-    mkdir -p $out/share
-  '';
+    patches = [
+      patchFiles.${colWidth}
+    ];
 
-  checkPhase = ''
-    xxd --version | grep ${version}
-  '';
-}
+    preInstall = ''
+      mkdir -p $out/share
+    '';
+
+    checkPhase = ''
+      xxd --version | grep ${version}
+    '';
+  }

--- a/flake.lock
+++ b/flake.lock
@@ -1,21 +1,20 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "lastModified": 1688466019,
+        "narHash": "sha256-VeM2akYrBYMsb4W/MmBo1zmaMfgbL4cH3Pu8PGyIwJ0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8e8d955c22df93dbe24f19ea04f47a74adbdc5ec",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
+        "id": "flake-parts",
+        "type": "indirect"
       }
     },
     "nixpkgs": {
@@ -34,25 +33,28 @@
         "type": "github"
       }
     },
-    "root": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "dir": "lib",
+        "lastModified": 1688049487,
+        "narHash": "sha256-100g4iaKC9MalDjUW9iN6Jl/OocTDtXdeAj7pEGIRh4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4bc72cae107788bf3f24f30db2e2f685c9298dc9",
         "type": "github"
       },
       "original": {
-        "owner": "nix-systems",
-        "repo": "default",
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
         "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
       }
     }
   },


### PR DESCRIPTION
Previously the overlay added an xxd attribute that pointed to a function, now the xxd attribute points to a ready to go derivation that can still have attributes overridden when necessary. We're also now using flake parts, which will export the more standard `overlays.default` structure.